### PR TITLE
Make cert manager email address optional

### DIFF
--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -263,7 +263,7 @@ spec:
         - name: cert_manager_email
           title: Email address
           type: text
-          required: true
+          required: false
           when: '{{repl ConfigOptionEquals "cert_manager_enabled" "1" }}'
           help_text: The email address to send renewal notifications to.
 


### PR DESCRIPTION
You don't need to set an email address for cert-manager (and I personally never add one for test installations). Therefore, I propose to make this optional.