### PR TITLE
Proposal: Set installer job restart policy to 'Never'

### DIFF
--- a/manifests/gitpod-installer-job.yaml
+++ b/manifests/gitpod-installer-job.yaml
@@ -17,7 +17,7 @@ spec:
         component: gitpod-installer
     spec:
       serviceAccountName: installer
-      restartPolicy: OnFailure
+      restartPolicy: Never
       initContainers:
         # Checks that the cert-manager installation is complete
         - name: cert-manager


### PR DESCRIPTION
The restart policy of the installer job is currently `OnFailure`. It seems, that when the installation job fails for some reason that the admin portal does not terminate the installation job but shows “in progress” pretty long.

Changing the restart policy to `Never` probably makes sense because when the installation fails we don't need to try it again and again but show an error instead, do we?

I haven't tested the failure behavior in detail yet. Maybe the folks from Replicated could give us a recommendation for what the proper restart policy value should be? @MrSimonEmms Could you ask them?